### PR TITLE
Dependency: switch to newer nuSOAP library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-db": "2.*",
         "zendframework/zendsearch": "^2.0@rc",
         "zendframework/zend-eventmanager": "^3.2",
-        "codecasts/nusoap-php7": "~0.9",
+        "econea/nusoap": "~0.9.7",
         "lcobucci/jwt": "~3.2"
     },
     "require-dev": {


### PR DESCRIPTION
Hi, I'm maintainer of https://github.com/econea/nusoap package. I would appreciate if you could test this newer library in your wcmf.  I am trying to build one rock solid library providing nuSOAP.