### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "eventviva/php-image-resize": "Use this package to resize images using Smarty plugins",
         "setasign/fpdi-fpdf": "Use this package to generate PDF files",
         "zf1/zend-http": "Use this package, if you want to communicate to other wCMF instances over HTTP",
-        "facebook/webdriver": "Use this package, if you want to run tests with SeleniumTestCase"
+        "php-webdriver/webdriver": "Use this package, if you want to run tests with SeleniumTestCase"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```